### PR TITLE
Added trademarks and link to settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## What is Karen Bot
 
-Karen bot is a Discord bot with many great features. It features Reddit commands, moderation commands, Spotify commands and much more.
+Karen bot is a Discord bot with many great features. It features Reddit commands, moderation commands, Spotify commands and much more. To view a full list of commands, [click here](users/commands.md)
 
 ## Special thanks to
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## What is Karen Bot
 
-Karen bot is a Discord bot with many great features. It features Reddit® commands, moderation commands, Spotify® commands and much more.
+Karen bot is a Discord bot with many great features. It features Reddit commands, moderation commands, Spotify commands and much more.
 
 ## Special thanks to
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## What is Karen Bot
 
-Karen bot is a Discord bot with many great features. It features reddit commands, moderation commands, spotify commands and much more.
+Karen bot is a Discord bot with many great features. It features Reddit® commands, moderation commands, Spotify® commands and much more.
 
 ## Special thanks to
 

--- a/index.html
+++ b/index.html
@@ -14,6 +14,8 @@
   <div id="app"></div>
   <script>
     let apiUrl = "https://cdn.exerra.xyz/karen/"
+    const spotifyRegex = /Spotify/ig
+    const redditRegex = /Reddit/ig
     window.$docsify = {
       name: 'Karen Bot docs',
       repo: 'https://github.com/Exerra-Discord/karen-bot-docs',
@@ -34,6 +36,13 @@
           // Except if it is README.md
           hook.beforeEach(function(html) {
             if (vm.route.file !== 'README.md') html = html.replaceAll('Karen Bot', "[Karen Bot](https://karen.exerra.xyz)")
+            return html
+          })
+
+          // Adds the registered ASCII symbol to registered trademarks
+          hook.afterEach(html => {
+            html = html.replaceAll(spotifyRegex, 'Spotify®')
+            html = html.replaceAll(redditRegex, 'Reddit®')
             return html
           })
         }


### PR DESCRIPTION
I wrote a simple little plugin that adds the trademark symbol to both Spotify and Reddit. WIll try to make it in a seperate JS file hosted on my CDN probably, but that is a topic for another day. This PR features a new plugin, sorta, and a link to settings in README