### PR TITLE
Fix command sorting

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,12 @@
               fetch(apiUrl + "commands")
                 .then(response => response.json())
                 .then(json => {
-                  this.commandsObj = json.commands
+                  this.commandsObj = json.commands.sort((a, b) => a.type.localeCompare(b.type));
+                  for (let i = this.commandsObj.length - 1; i >= 0; i--) {
+                    if (this.commandsObj[i].type == 'Private') {
+                      this.commandsObj.splice(i, 1)
+                    }
+                  }
                 })
             }
           })

--- a/users/commands.md
+++ b/users/commands.md
@@ -6,8 +6,6 @@ This section provides documentation about the commands. These commands are updat
 ## Regular commands
 These are the commands that get executed by running "m!command"
 
-!> The table will get sorted, but for now, uh, suck it up
-
 <div id="commandsDiv">
 	<table class="sortable">
 		<tr>


### PR DESCRIPTION
So I tried to add a horrible command sorting mechanism before, but it kind of sucked... big time
So this pull request has a way better sorting mechanism that sorts the data before it even reaches the table! IT sorts as soon as it gets the JSON data :)